### PR TITLE
Az2009_Rede :: Ajustes - Inclusao de verificação se o softdescription…

### DIFF
--- a/Model/Method/Dc/Request/Payment.php
+++ b/Model/Method/Dc/Request/Payment.php
@@ -49,39 +49,45 @@ class Payment extends \Az2009\Rede\Model\Method\Cc\Request\Payment
         $this->setInfo($info);
         $this->setPayment($payment);
 
-        return $this->setData(
-            [
-                'kind' => Payment::TYPE,
-                'Amount' => $this->helper->formatNumber($info->getAmount()),
-                'capture' => true,
-                'softDescriptor' => $this->helper->prepareString($this->getSoftDescriptor(), 13, 0),
-                'cardNumber' => $this->getInfo()->getAdditionalInformation('cc_number'),
-                'cardHolderName' => $this->getInfo()->getAdditionalInformation('cc_name'),
-                'expirationMonth' => $this->getExpMonth(),
-                'expirationYear' => $this->getExpYear(),
-                'subscription' => false,
-                'Origin' => 1,
-                'distributorAffiliation' => $this->helper->getMerchantId(),
-                'securityCode' => $this->getInfo()->getAdditionalInformation('cc_cid'),
-                'Brand' => $this->_cctype->getBrandFormatRede($this->getInfo()->getAdditionalInformation('cc_type')),
-                'threeDSecure' => [
-                    'embedded' => true,
-                    'onFailure' => 'decline',
-                    'userAgent' => $this->httpHeader->getHttpUserAgent()
-                ],
-                'urls' =>
+        $paymentData = [
+            'kind' => Payment::TYPE,
+            'Amount' => $this->helper->formatNumber($info->getAmount()),
+            'capture' => true,
+            'cardNumber' => $this->getInfo()->getAdditionalInformation('cc_number'),
+            'cardHolderName' => $this->getInfo()->getAdditionalInformation('cc_name'),
+            'expirationMonth' => $this->getExpMonth(),
+            'expirationYear' => $this->getExpYear(),
+            'subscription' => false,
+            'Origin' => 1,
+            'distributorAffiliation' => $this->helper->getMerchantId(),
+            'securityCode' => $this->getInfo()->getAdditionalInformation('cc_cid'),
+            'Brand' => $this->_cctype->getBrandFormatRede($this->getInfo()->getAdditionalInformation('cc_type')),
+            'threeDSecure' => [
+                'embedded' => true,
+                'onFailure' => 'decline',
+                'userAgent' => $this->httpHeader->getHttpUserAgent()
+            ],
+            'urls' =>
+                [
                     [
-                        [
-                            'kind' => 'threeDSecureSuccess',
-                            'url'  => $this->getReturnUrl()
-                        ],
-                        [
-                            'kind' => 'threeDSecureFailure',
-                            'url'  => $this->getReturnUrl()
-                        ]
+                        'kind' => 'threeDSecureSuccess',
+                        'url'  => $this->getReturnUrl()
+                    ],
+                    [
+                        'kind' => 'threeDSecureFailure',
+                        'url'  => $this->getReturnUrl()
                     ]
-            ]
-        )->toArray();
+                ]
+        ];
+
+        if($this->getSoftDescriptorEnable()){
+            $softDescriptor = $this->helper->prepareString($this->getSoftDescriptor(), 13, 0);
+            if (!empty($softDescriptor)){
+                $paymentData['softDescriptor'] = $softDescriptor;
+            }
+        }
+
+        return $this->setData($paymentData)->toArray();
     }
 
     /**

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -57,15 +57,31 @@
                         <field id="active">1</field>
                     </depends>
                 </field>
+                <field id="billing_description_active" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Billing Description Enable</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                    <comment>A Rede permite que o lojista envie um texto complementar que será impresso na fatura do comprador junto com a identificação do nome da loja que consta no cadastro Rede. (Serviço deve ser habilitado com a Rede)</comment>
+                </field>
                 <field id="billing_description" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Billing Description</label>
                     <depends>
                         <field id="active">1</field>
+                        <field id="billing_description_active">1</field>
                     </depends>
                 </field>
                 <field id="payment_action" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Payment Action</label>
                     <source_model>Magento\Authorizenet\Model\Source\PaymentAction</source_model>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                </field>
+                <field id="payment_antifraude" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Habilitar Antifraude Rede?</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>
                         <field id="active">1</field>
                     </depends>

--- a/i18n/pt_BR.csv
+++ b/i18n/pt_BR.csv
@@ -119,3 +119,4 @@
 "CARDHOLDER NAME","NOME DO TITULAR DO CARTÃO"
 "Select Credit Card","Selecione um Cartão de Crédito"
 "Other Credit Card","Outro Cartão de Crédito"
+"Billing Description Enable","Habilitar - Descrição da Cobrança"


### PR DESCRIPTION
### Problema:
Ao tentar realizar os testes de transação é retornado o erro: 
```"returnCode":"63","returnMessage":"Softdescriptor: Not enabled for this merchant."```

Segue o log do erro:
```
[2020-07-20 12:46:46] .INFO: 

 Request - : {
"reference":"000000090",
"kind":"credit",
"Amount":23900,
"installments":1,
"capture":true,
"softDescriptor":"Billing Descr",
"cardNumber":"4111111111111111",
"cardHolderName":"Lucas Apoena",
"expirationMonth":"11",
"expirationYear":"2021",
"subscription":false,
"Origin":1,
"distributorAffiliation":"084593520",
"securityCode":"321",
"Brand":"Visa"
}

 Response - : 
 HTTP/1.1 422 Unprocessable Entity
Content-length: 84
Content-type: application/json; charset=utf-8
Expires: Mon, 20 Jul 2020 12:46:46 GMT
Cache-control: max-age=0, no-cache, no-store
Pragma: no-cache
Date: Mon, 20 Jul 2020 12:46:46 GMT
Connection: close

{"returnCode":"63","returnMessage":"Softdescriptor: Not enabled for this merchant."} 
```

### Solução sugerida:
Foi implementado para que este campo possa ser habilitado/desabilitado pelo cliente. Com isto caso o plano contratado com a Rede não possua este serviço, o cliente poderá desabilitar o envio deste campo. 

![image](https://user-images.githubusercontent.com/135553/88051459-05d57c80-cb2f-11ea-9903-ccd18ca5de42.png)


